### PR TITLE
Catch ssh avec regex

### DIFF
--- a/ssh_tunnel/proxy/filters/OpenSSHStringFilter.py
+++ b/ssh_tunnel/proxy/filters/OpenSSHStringFilter.py
@@ -4,6 +4,9 @@ from ssh_tunnel.proxy.filters import blacklist, Filter
 import re
 
 
+prog = re.compile(b'^SSH-[0-9]+(\.)?[0-9]?-(.*?) ')
+
+
 class OpenSSHStringFilter(Filter):
     """
     Finds the OpenSSH version exchange at the begining of the protocol
@@ -14,7 +17,6 @@ class OpenSSHStringFilter(Filter):
     Let's regex this...
     """
     def drop(self, path, headers, body):
-        prog = re.compile('^SSH-[0-9]+(\.)?[0-9]?-(.*?) ')
         bodies = []
         # Construct a list of decoded bodies
         bodies.append(body)
@@ -24,7 +26,7 @@ class OpenSSHStringFilter(Filter):
             logging.debug("not a base64")
 
         for target in bodies:
-            if prog.match(target.decode()):
+            if prog.match(target):
                 logging.info("Openssh detected")
                 blacklist(path)
                 return True

--- a/ssh_tunnel/proxy/filters/OpenSSHStringFilter.py
+++ b/ssh_tunnel/proxy/filters/OpenSSHStringFilter.py
@@ -1,21 +1,33 @@
 import binascii
 import logging
 from ssh_tunnel.proxy.filters import blacklist, Filter
+import re
 
 
 class OpenSSHStringFilter(Filter):
-    """Finds the OpenSSH version exchange at the begining of the protocol"""
+    """
+    Finds the OpenSSH version exchange at the begining of the protocol
+    Info : according to the ssh rfc4253:
+    "When the connection has been established, both sides MUST send an
+    identification string.  This identification string MUST be
+             SSH-protoversion-softwareversion
+    Let's regex this...
+    """
     def drop(self, path, headers, body):
+        prog = re.compile('^SSH-[0-9]+(\.)?[0-9]?-(.*?) ')
         bodies = []
         # Construct a list of decoded bodies
         bodies.append(body)
         try:
             bodies.append(binascii.a2b_base64(body))
+            print("=======================")
+            print(bodies)
         except binascii.Error:
             logging.debug("not a base64")
 
         for target in bodies:
-            if len(target) < 32 and b"OpenSSH" in target:
+            print("length targer = " + str(len(target)))
+            if prog.match(target.decode()):
                 logging.info("Openssh detected")
                 blacklist(path)
                 return True

--- a/ssh_tunnel/proxy/filters/OpenSSHStringFilter.py
+++ b/ssh_tunnel/proxy/filters/OpenSSHStringFilter.py
@@ -24,7 +24,6 @@ class OpenSSHStringFilter(Filter):
             logging.debug("not a base64")
 
         for target in bodies:
-            print("length targer = " + str(len(target)))
             if prog.match(target.decode()):
                 logging.info("Openssh detected")
                 blacklist(path)

--- a/ssh_tunnel/proxy/filters/OpenSSHStringFilter.py
+++ b/ssh_tunnel/proxy/filters/OpenSSHStringFilter.py
@@ -20,8 +20,6 @@ class OpenSSHStringFilter(Filter):
         bodies.append(body)
         try:
             bodies.append(binascii.a2b_base64(body))
-            print("=======================")
-            print(bodies)
         except binascii.Error:
             logging.debug("not a base64")
 

--- a/ssh_tunnel/proxy/filters/__init__.py
+++ b/ssh_tunnel/proxy/filters/__init__.py
@@ -11,7 +11,7 @@ class Filter():
         raise Exception("Should be implemented")
 
     def __str__(self):
-        return self.__name__
+        return type(self).__name__
 
 
 def blacklist(path):


### PR DESCRIPTION
Mon message de ssh faisait plus de 32 character.

En regardant la rfc, je me suis rendu compte que les message était toujours formaté pareil.
Donc en faisant une regex qui cherche un message qui débute par SSH-[version]-[prog], on a plus à s'embeter avec une verif de longueure.

Et c'est ma première pull request :)